### PR TITLE
Add language / text editor choice as positional arguments

### DIFF
--- a/labelling_helper.py
+++ b/labelling_helper.py
@@ -2,15 +2,22 @@ import requests
 import justext
 import os
 import shutil
+import argparse
 
+parser = argparse.ArgumentParser()
 
-lang = 'zh'
+parser.add_argument('lang', help="target language")
+parser.add_argument('editor', help="text editor to use, default is vim", default="vim")
+args = parser.parse_args()
+
+lang = args.lang
+editor = args.editor
 
 while True:
-    url = input().strip()
-    slug = input().strip()
+    url = input("enter url: ").strip()
+    slug = input("enter name for data in format 'websitetype-title',\ni.e forum-aialignmentforum-FoiiRDC3E$
 
-    html = requests.get(url, headers={'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36'}).content
+    html = requests.get(url, headers={'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit$
     all_paras = [para.text for para in justext.justext(html, justext.get_stoplist("English"))]
 
     with open('tmp', 'w') as fh:
@@ -18,7 +25,7 @@ while True:
     with open('html', 'wb') as fh:
         fh.write(html)
 
-    os.system('vim tmp')
+    os.system(f'{editor} tmp')
 
     shutil.move('tmp', f'benchmarkdata/{lang}/text/{slug}.txt')
     shutil.move('html', f'benchmarkdata/{lang}/html/{slug}.html')

--- a/labelling_helper.py
+++ b/labelling_helper.py
@@ -7,7 +7,7 @@ import argparse
 parser = argparse.ArgumentParser()
 
 parser.add_argument('lang', help="target language")
-parser.add_argument('editor', help="text editor to use, default is vim", default="vim")
+parser.add_argument('--editor', help="text editor to use, default is vim", required=False, default="vim")
 args = parser.parse_args()
 
 lang = args.lang
@@ -15,9 +15,9 @@ editor = args.editor
 
 while True:
     url = input("enter url: ").strip()
-    slug = input("enter name for data in format 'websitetype-title',\ni.e forum-aialignmentforum-FoiiRDC3E$
+    slug = input("enter name for data in format 'websitetype-title': ").strip()
 
-    html = requests.get(url, headers={'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit$
+    html = requests.get(url, headers={'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36'}).content
     all_paras = [para.text for para in justext.justext(html, justext.get_stoplist("English"))]
 
     with open('tmp', 'w') as fh:
@@ -29,3 +29,5 @@ while True:
 
     shutil.move('tmp', f'benchmarkdata/{lang}/text/{slug}.txt')
     shutil.move('html', f'benchmarkdata/{lang}/html/{slug}.html')
+
+


### PR DESCRIPTION
Usage:

positional arguments:
  lang        target language
  editor      text editor to use, default is vim

optional arguments:
  -h, --help  show this help message and exit

e.g 

python labelling_helper.py en nano